### PR TITLE
Initialise go module and containerise Motion

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,18 @@
+name: Build
+
+on: [ pull_request ]
+
+jobs:
+  build:
+    name: Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Container image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,0 +1,44 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    name: Container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.20-bullseye as build
+
+WORKDIR /go/src/motion
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /go/bin/motion ./cmd/motion
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=build /go/bin/motion /usr/bin/
+
+ENTRYPOINT ["/usr/bin/motion"]

--- a/cmd/motion/main.go
+++ b/cmd/motion/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello world from motion!")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/filecoin-project/motion
+
+go 1.20


### PR DESCRIPTION
Define Motion go module, and add the initial dockerfile with two CI builds: one to build the container on PR, and one to publish it to ghcr.io for user convenience.