### PR TITLE
Fix `tags` in container publication CI job

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -28,13 +28,14 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          tags: |
-            type=semver,pattern={{version}}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
`tags` was set on the wrong step. While at it, also tag as branch.