### PR TITLE
Extend blob store to return status and handle /status

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -1,5 +1,7 @@
 package api
 
+import "time"
+
 type (
 	// PostBlobResponse represents the response to a successful POST request to upload a blob.
 	PostBlobResponse struct {
@@ -10,5 +12,15 @@ type (
 	ErrorResponse struct {
 		// Error is the description of the error.
 		Error string `json:"error"`
+	}
+	GetStatusResponse struct {
+		ID       string    `json:"id"`
+		Replicas []Replica `json:"Replicas,omitempty"`
+	}
+	Replica struct {
+		Provider     string    `json:"provider"`
+		Status       string    `json:"status"`
+		LastVerified time.Time `json:"lastVerified"`
+		Expiration   time.Time `json:"expiration"`
 	}
 )

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -12,7 +12,6 @@ var (
 	errResponseBlobNotFound         = api.ErrorResponse{Error: "No blob is found for the given ID"}
 	errResponseNotStreamContentType = api.ErrorResponse{Error: `Invalid content type, expected "application/octet-stream".`}
 	errResponseInvalidContentLength = api.ErrorResponse{Error: "Invalid content length, expected unsigned numerical value."}
-	errResponseNotImplemented       = api.ErrorResponse{Error: "This functionally is pending implementation."}
 )
 
 func errResponseInternalError(err error) api.ErrorResponse {

--- a/api/server/util.go
+++ b/api/server/util.go
@@ -31,7 +31,9 @@ func httpHeaderAllow(methods ...string) (string, string) {
 func respondWithJson(w http.ResponseWriter, resp any, code int) {
 	w.Header().Set(httpHeaderContentTypeJson())
 	w.Header().Set(httpHeaderContentTypeOptionsNoSniff())
-	w.WriteHeader(code)
+	if code != http.StatusOK {
+		w.WriteHeader(code)
+	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		logger.Errorw("Failed to encode response.", "code", code, "resp", resp, "err", err)
 	}

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -25,10 +25,21 @@ type (
 		Size uint64
 		// ModificationTime is the latest time at which the blob was modified.
 		ModificationTime time.Time
+		Status           *Status
+	}
+	Status struct {
+		Replicas []Replica
+	}
+	Replica struct {
+		Provider     string
+		Status       string
+		LastVerified time.Time
+		Expiration   time.Time
 	}
 	Store interface {
 		Put(context.Context, io.ReadCloser) (*Descriptor, error)
-		Get(context.Context, ID) (io.ReadSeekCloser, *Descriptor, error)
+		Describe(context.Context, ID) (*Descriptor, error)
+		Get(context.Context, ID) (io.ReadSeekCloser, error)
 	}
 )
 


### PR DESCRIPTION
Change the blob store interface to separate `Describe` from `Get`, and extend the content of `blob.Descriptor` to include `blob.Status`.

Reflect the changes on the existing stores. Leave TODOs in place for the actual information fetching of the deals made by the store to be implemented in separate PRs.

Change the sever to correctly handle `GET /v0/blob/{id}/status`.