### PR TITLE
Signal content length to upstream components when present

### DIFF
--- a/.github/actions/go-check-setup/action.yml
+++ b/.github/actions/go-check-setup/action.yml
@@ -6,7 +6,9 @@ runs:
     - name: Install filecoin-ffi dependencies
       shell: bash
       if: ${{ runner.os == 'Linux' }}
-      run: sudo apt-get install -y libhwloc-dev ocl-icd-opencl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libhwloc-dev ocl-icd-opencl-dev
     - name: Install filecoin-ffi
       shell: bash
       run: |

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -6,7 +6,9 @@ runs:
     - name: Install filecoin-ffi dependencies
       shell: bash
       if: ${{ runner.os == 'Linux' }}
-      run: sudo apt-get install -y libhwloc-dev ocl-icd-opencl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libhwloc-dev ocl-icd-opencl-dev
     - name: Install filecoin-ffi
       shell: bash
       if: ${{ runner.os == 'Linux' }}

--- a/api/server/sizer_reader.go
+++ b/api/server/sizer_reader.go
@@ -1,0 +1,14 @@
+package server
+
+import "io"
+
+var _ interface{ Size() int64 } = (*sizerReadCloser)(nil)
+
+type sizerReadCloser struct {
+	io.ReadCloser
+	size int64
+}
+
+func (s sizerReadCloser) Size() int64 {
+	return s.size
+}


### PR DESCRIPTION
When the HTTP request contains `Content-Length` header, include it in the body reader passed down to upstream system components. This is to enable further optimisations during processing when the total size of a blob is known beforehand. Examples include piece selection in order to guarantee that a blob will be fully contained within a piece.

With changes introduced, an upstream component may type-check for `interface { Size() int64 }` and use it to then gain access to the content length.

Note that based on HTTP standards, `application/octet-stream` content type is not strictly required to specify `Content-Length` header. Hence the opportunistic signalling via type-checkers.