### PR TITLE
Add replication and deal making policy configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,24 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --storeDir value                                                             The path at which to store Motion data (default: OS Temporary directory) [$MOTION_STORE_DIR]
+   --dealDuration value                                                         The duration of deals made on Filecoin (default: One year (356 days))
+   --dealStartDelay value                                                       The deal start epoch delay. (default: 72 hours)
+   --experimentalRemoteSingularityAPIUrl value                                  When using a singularity as the storage engine, if set, uses a remote HTTP API to interface with Singularity (default: use singularity as a code library)
+   --experimentalSingularityStore                                               Whether to use experimental Singularity store as the storage and deal making engine (default: Local storage is used)
+   --help, -h                                                                   show help
    --localWalletDir value                                                       The path to the local wallet directory. (default: Defaults to '<user-home-directory>/.motion/wallet' with wallet key auto-generated if not present. Note that the directory permissions must be at most 0600.) [$MOTION_LOCAL_WALLET_DIR]
    --localWalletGenerateIfNotExist                                              Whether to generate the local wallet key if none is found (default: true)
-   --experimentalSingularityStore                                               whether to use experimental Singularity store as the storage and deal making engine (default: Local storage is used)
-   --experimentalRemoteSingularityAPIUrl value                                  when using a singularity as the storage engine, if set, uses a remote HTTP API to interface with Singularity (default: use singularity as a code library)
+   --pricePerDeal value                                                         The maximum price per deal in attoFIL. (default: 0)
+   --pricePerGiB value                                                          The maximum  price per GiB in attoFIL. (default: 0)
+   --pricePerGiBEpoch value                                                     The maximum price per GiB per Epoch in attoFIL. (default: 0)
+   --replicationFactor value                                                    The number of desired replicas per blob (default: Number of storage providers; see 'storageProvider' flag.)
    --storageProvider value, --sp value [ --storageProvider value, --sp value ]  Storage providers to which to make deals with. Multiple providers may be specified. (default: No deals are made to replicate data onto storage providers.)
-   --help, -h                                                                   show help
+   --storeDir value                                                             The path at which to store Motion data (default: OS Temporary directory) [$MOTION_STORE_DIR]
+
+   Lotus
+
+   --lotusApi value    Lotus RPC API endpoint (default: "https://api.node.glif.io/rpc/v1") [$LOTUS_API]
+   --lotusToken value  Lotus RPC API token [$LOTUS_TOKEN]
 ```
 
 ## Run Server Locally

--- a/cmd/motion/main.go
+++ b/cmd/motion/main.go
@@ -55,12 +55,12 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name:        "experimentalSingularityStore",
-				Usage:       "whether to use experimental Singularity store as the storage and deal making engine",
+				Usage:       "Whether to use experimental Singularity store as the storage and deal making engine",
 				DefaultText: "Local storage is used",
 			},
 			&cli.StringFlag{
 				Name:        "experimentalRemoteSingularityAPIUrl",
-				Usage:       "when using a singularity as the storage engine, if set, uses a remote HTTP API to interface with Singularity",
+				Usage:       "When using a singularity as the storage engine, if set, uses a remote HTTP API to interface with Singularity",
 				DefaultText: "use singularity as a code library",
 			},
 			&cli.StringSliceFlag{


### PR DESCRIPTION
Add configuration options to allow a user to control the replication factor, and deal making parameters such as price, start delay and duration.

Add corresponding CLI flag for each of the options.

Fixes #19