### PR TITLE
Fix CI docker publish failing due to cache support

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build Container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           cache-from: type=gha

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -37,7 +39,7 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=branch
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           cache-from: type=gha


### PR DESCRIPTION
Set up build with docker buildx to take advantage of caching. Otherwise, since caching parameters are set publishing of images fail.