### PR TITLE
Support Testnet mode

### DIFF
--- a/cmd/motion/main.go
+++ b/cmd/motion/main.go
@@ -84,6 +84,11 @@ func main() {
 				Value:    "",
 				EnvVars:  []string{"LOTUS_TOKEN"},
 			},
+			&cli.BoolFlag{
+				Name:     "lotus-test",
+				Category: "Lotus",
+				EnvVars:  []string{"LOTUS_TEST"},
+			},
 			&cli.UintFlag{
 				Name:        "replicationFactor",
 				Usage:       "The number of desired replicas per blob",
@@ -141,6 +146,11 @@ func main() {
 			},
 		},
 		Action: func(cctx *cli.Context) error {
+			lotusTest := cctx.Bool("lotus-test")
+			if lotusTest {
+				address.CurrentNetwork = address.Testnet
+			}
+
 			storeDir := cctx.String("storeDir")
 			var store blob.Store
 			if cctx.Bool("experimentalSingularityStore") {


### PR DESCRIPTION
# Goals

Add cli option to use in a lotus testnet. This is important cause while not obvious, all lotus addreses are serialized by go-address based off a global package var (bizarre behavior, but subject for another time). So they will read either "t..." or "f..." when written as a string based on address.CurrentNetwork.