### PR TITLE
Remove the makefile now that it only contains go make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-SHELL=/usr/bin/env bash
-.DEFAULT_GOAL := build
-
-.PHONY: build
-build:
-	go build ./...
-
-.PHONY: clean
-clean:


### PR DESCRIPTION
Makefile as is, is too simple to justify its existence. Remove it.