### PR TITLE
Remove redundant wallet directory env var

### DIFF
--- a/docker-compose-local-dev.yml
+++ b/docker-compose-local-dev.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3.8'
 
 services:
   db:
@@ -53,7 +53,6 @@ services:
       - 40080:40080
     environment:
       - MOTION_STORE_DIR=/usr/src/app/storage
-      - MOTION_LOCAL_WALLET_DIR=/usr/src/app/wallet
       - LOTUS_TEST
       - LOTUS_API
       - LOTUS_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,6 @@ services:
       - 40080:40080
     environment:
       - MOTION_STORE_DIR=/usr/src/app/storage
-      - MOTION_LOCAL_WALLET_DIR=/usr/src/app/wallet
       - LOTUS_TEST
       - LOTUS_API
       - LOTUS_TOKEN

--- a/integration/test/motionlarity/docker-compose.yaml
+++ b/integration/test/motionlarity/docker-compose.yaml
@@ -119,7 +119,6 @@ services:
     restart: unless-stopped
     environment:
       - MOTION_STORE_DIR=/usr/src/app/storage
-      - MOTION_LOCAL_WALLET_DIR=/usr/src/app/wallet
       - LOTUS_TEST
       - LOTUS_API
       - LOTUS_TOKEN


### PR DESCRIPTION
Remove the no longer in-use wallet dir environment variable from docker compose files.

Rename the local dev docker compose to match naming convention.

Update version number in docker compose files that use newer syntax to avoid local validation errors.