### PR TITLE
Fix typo in container publication CI job

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ needs.prepare_checkout.outputs.ref }}
+          ref: ${{ needs.prepare-checkout.outputs.ref }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
@@ -52,8 +52,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             type=ref,event=branch
+            type=raw,value=${{ needs.prepare-checkout.outputs.ref }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Fix typo in container publication CI job and use raw tag for consistent container tagging regardless of build on trigger.