### PR TITLE
Fix runPreparationJobs exiting immediately

### DIFF
--- a/integration/singularity/options.go
+++ b/integration/singularity/options.go
@@ -60,6 +60,9 @@ func newOptions(o ...Option) (*options, error) {
 		maxPendingDealSize:    "0",
 		maxPendingDealNumber:  0,
 		cleanupInterval:       time.Hour,
+		pricePerGiBEpoch:      abi.NewTokenAmount(0),
+		pricePerGiB:           abi.NewTokenAmount(0),
+		pricePerDeal:          abi.NewTokenAmount(0),
 	}
 	for _, apply := range o {
 		if err := apply(opts); err != nil {

--- a/integration/singularity/store.go
+++ b/integration/singularity/store.go
@@ -276,16 +276,15 @@ func (l *SingularityStore) Start(ctx context.Context) error {
 
 func (l *SingularityStore) runPreparationJobs() {
 	l.closed.Add(1)
+	defer l.closed.Done()
 
+	// Create a context that gets canceled when this function exits.
 	ctx, cancel := context.WithCancel(context.Background())
-	defer func() {
-		cancel()
-		l.closed.Done()
-	}()
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-l.closing:
+			cancel()
 			return
 		case fileID := <-l.toPack:
 			prepareToPackSourceRes, err := l.singularityClient.File.PrepareToPackFile(&file.PrepareToPackFileParams{

--- a/integration/singularity/store_test.go
+++ b/integration/singularity/store_test.go
@@ -1,0 +1,83 @@
+package singularity_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	singularityclient "github.com/data-preservation-programs/singularity/client/swagger/http"
+	"github.com/filecoin-project/motion/integration/singularity"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorePut(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(testHandler))
+	t.Cleanup(func() {
+		testServer.Close()
+	})
+
+	cfg := singularityclient.DefaultTransportConfig()
+	u, _ := url.Parse(testServer.URL)
+	cfg.Host = u.Host
+	singularityAPI := singularityclient.NewHTTPClientWithConfig(nil, cfg)
+
+	tmpDir := t.TempDir()
+	s, err := singularity.NewStore(
+		singularity.WithStoreDir(tmpDir),
+		singularity.WithWalletKey("dummy"),
+		singularity.WithSingularityClient(singularityAPI),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	s.Start(ctx)
+
+	testFile := filepath.Join(tmpDir, "testdata.txt")
+	f, err := os.Create(testFile)
+	require.NoError(t, err)
+	_, err = f.WriteString("Halló heimur!")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	f, err = os.Open(testFile)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		f.Close()
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Putting test file more than size put queue. If this blocks, then
+		// store.toPack channel is not being read.
+		for i := 0; i < singularity.PutQueueSize+1; i++ {
+			desc, err := s.Put(ctx, f)
+			require.NoError(t, err)
+			require.NotNil(t, desc)
+		}
+	}()
+
+	timer := time.NewTimer(time.Second)
+	select {
+	case <-done:
+	case <-timer.C:
+		require.FailNow(t, "Put queue is not being read, check that store.runPreparationJobs is running")
+	}
+	timer.Stop()
+
+	err = s.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func testHandler(w http.ResponseWriter, req *http.Request) {
+	defer req.Body.Close()
+
+	if req.URL.Path == "/api/preparation/MOTION_PREPARATION/schedules" && req.Method == http.MethodGet {
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+}


### PR DESCRIPTION
runPreparationJobs exits immediately and cancels its goroutine. This prevents the goroutine from servicing the `SingularityStore.toPack` channel, which then causes that to block after 16 writes.

Added a unit test that fails before this PR and succeeds after.

Fixes #140