### PR TITLE
Correct when the the current network global var is set

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .github
 *.md
 integration/test
+docker-compose*.yml

--- a/cmd/motion/main.go
+++ b/cmd/motion/main.go
@@ -76,13 +76,6 @@ func main() {
 				Name:     "lotus-test",
 				Category: "Lotus",
 				EnvVars:  []string{"LOTUS_TEST"},
-				Action: func(context *cli.Context, lotusTest bool) error {
-					if lotusTest {
-						logger.Info("Current network is set to Testnet")
-						address.CurrentNetwork = address.Testnet
-					}
-					return nil
-				},
 			},
 			&cli.UintFlag{
 				Name:        "replicationFactor",
@@ -165,6 +158,12 @@ func main() {
 			},
 		},
 		Action: func(cctx *cli.Context) error {
+			if cctx.Bool("lotus-test") {
+				logger.Info("Current network is set to Testnet")
+				address.CurrentNetwork = address.Testnet
+			} else {
+				address.CurrentNetwork = address.Mainnet
+			}
 			storeDir := cctx.String("storeDir")
 			var store blob.Store
 			if cctx.Bool("experimentalSingularityStore") {


### PR DESCRIPTION
The Action for the flag is only executed when the flag is set. 
In go-address package, `address.CurrentNetwork` is initialized to `address.Testnet`. So we need to check `--lotus-test` and set it to `address.Mainet` if the flag is not set.