### PR TITLE
chore!: replace "Replicas" with "replicas" in JSON response

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ curl http://localhost:40080/v0/blob/ad7ef987-a932-495c-aa0c-7ffcabeda45f/status 
 ```json
 {
   "id": "ad7ef987-a932-495c-aa0c-7ffcabeda45f",
-  "Replicas": [
+  "replicas": [
     {
       "provider": "f1234",
       "status": "active",

--- a/api/model.go
+++ b/api/model.go
@@ -15,7 +15,7 @@ type (
 	}
 	GetStatusResponse struct {
 		ID       string    `json:"id"`
-		Replicas []Replica `json:"Replicas,omitempty"`
+		Replicas []Replica `json:"replicas,omitempty"`
 	}
 	Replica struct {
 		Provider string  `json:"provider"`


### PR DESCRIPTION
This is a BREAKING change but it's really out of place in the schema; probably not uncomfortable for native Go eyes but when I put on my JS (JSON) glasses it's jarring.

Can we fix this now before we bake it in as a thing and make it even more difficult to change later?