### PR TITLE
fix: docker compose down with --rmi=local on cleanup

### DIFF
--- a/integration/test/Makefile
+++ b/integration/test/Makefile
@@ -42,7 +42,7 @@ devnet/down:
 motionlarity/up: ./motionlarity/.up
 
 motionlarity/down: devnet/down
-	docker compose -f ./motionlarity/docker-compose.yaml down --rmi=all --volumes
+	docker compose -f ./motionlarity/docker-compose.yaml down --rmi=local --volumes
 	rm -f ./motionlarity/.up || true
 	rm -f ./motionlarity/.env.local || true
 	rm -f ./devnet/.boostready || true


### PR DESCRIPTION
A bit annoying to have to download it all again just to start up when doing this locally (with bad internet)