### PR TITLE
fix: remove unnecessary lotus CLI arguments (also: why are these here?)

### DIFF
--- a/cmd/motion/main.go
+++ b/cmd/motion/main.go
@@ -61,20 +61,6 @@ func main() {
 				DefaultText: "No deals are made to replicate data onto storage providers.",
 				EnvVars:     []string{"MOTION_STORAGE_PROVIDERS"},
 			},
-			&cli.StringFlag{
-				Name:     "lotusApi",
-				Category: "Lotus",
-				Usage:    "Lotus RPC API endpoint",
-				Value:    "https://api.node.glif.io/rpc/v1",
-				EnvVars:  []string{"LOTUS_API"},
-			},
-			&cli.StringFlag{
-				Name:     "lotusToken",
-				Category: "Lotus",
-				Usage:    "Lotus RPC API token",
-				Value:    "",
-				EnvVars:  []string{"LOTUS_TOKEN"},
-			},
 			&cli.BoolFlag{
 				Name:     "lotus-test",
 				Category: "Lotus",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,6 @@ services:
     environment:
       - MOTION_STORE_DIR=/usr/src/app/storage
       - LOTUS_TEST
-      - LOTUS_API
-      - LOTUS_TOKEN
       - MOTION_STORAGE_PROVIDERS
       - MOTION_PRICE_PER_GIB_EPOCH
       - MOTION_PRICE_PER_GIB

--- a/integration/test/motionlarity/docker-compose.yaml
+++ b/integration/test/motionlarity/docker-compose.yaml
@@ -140,8 +140,6 @@ services:
     environment:
       - MOTION_STORE_DIR=/usr/src/app/storage
       - LOTUS_TEST
-      - LOTUS_API
-      - LOTUS_TOKEN
       - MOTION_STORAGE_PROVIDERS
       - MOTION_PRICE_PER_GIB_EPOCH
       - MOTION_PRICE_PER_GIB


### PR DESCRIPTION
I'm not actually sure why these were here; perhaps they were originally needed to pass through directly to singularity somehow?