### PR TITLE
Remove redundant package name from type name

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1181,6 +1181,7 @@ github.com/ipfs/go-unixfsnode v1.5.1/go.mod h1:ed79DaG9IEuZITJVQn4U6MZDftv6I3ygU
 github.com/ipfs/go-unixfsnode v1.7.1/go.mod h1:PVfoyZkX1B34qzT3vJO4nsLUpRCyhnMuHBznRcXirlk=
 github.com/ipfs/go-unixfsnode v1.7.4/go.mod h1:PVfoyZkX1B34qzT3vJO4nsLUpRCyhnMuHBznRcXirlk=
 github.com/ipfs/go-unixfsnode v1.8.0/go.mod h1:HxRu9HYHOjK6HUqFBAi++7DVoWAHn0o4v/nZ/VA+0g8=
+github.com/ipfs/go-unixfsnode v1.9.0 h1:ubEhQhr22sPAKO2DNsyVBW7YB/zA8Zkif25aBvz8rc8=
 github.com/ipfs/go-unixfsnode v1.9.0/go.mod h1:HxRu9HYHOjK6HUqFBAi++7DVoWAHn0o4v/nZ/VA+0g8=
 github.com/ipfs/interface-go-ipfs-core v0.10.0/go.mod h1:F3EcmDy53GFkF0H3iEJpfJC320fZ/4G60eftnItrrJ0=
 github.com/ipld/go-car v0.5.0/go.mod h1:ppiN5GWpjOZU9PgpAZ9HbZd9ZgSpwPMr48fGRJOWmvE=

--- a/integration/test/integration_test.go
+++ b/integration/test/integration_test.go
@@ -100,9 +100,11 @@ func TestRoundTripPutStatusAndFullStorage(t *testing.T) {
 			var decoded api.GetStatusResponse
 			err = jsonResp.Decode(&decoded)
 			assert.NoError(c, err)
-			assert.Len(c, decoded.Replicas, 2)
-			assert.Len(c, decoded.Replicas[0].Pieces, 1)
-			assert.Len(c, decoded.Replicas[1].Pieces, 1)
+			assert.Len(t, decoded.Replicas, 2)
+			if len(decoded.Replicas) == 2 {
+				assert.Len(c, decoded.Replicas[0].Pieces, 1)
+				assert.Len(c, decoded.Replicas[1].Pieces, 1)
+			}
 		}, 2*time.Minute, 5*time.Second, "never initiated deal making")
 	}
 


### PR DESCRIPTION
Types should not be named with the package name as part of the type name, as this is redundant.