### PR TITLE
feat: add cleanup test, and isolate id mapping code and cleanup code

### DIFF
--- a/blob/local_store.go
+++ b/blob/local_store.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"strings"
+
 	"github.com/gammazero/fsutil/disk"
 )
 
@@ -127,4 +129,48 @@ func (l *LocalStore) Describe(ctx context.Context, id ID) (*Descriptor, error) {
 		Size:             uint64(stat.Size()),
 		ModificationTime: stat.ModTime(),
 	}, nil
+}
+
+// Lists all locally stored blob IDs. Files in the local store directory which
+// do not end in ".bin", or which cannot be parsed into a blob ID, will not be
+// included.
+func (l *LocalStore) List(ctx context.Context) ([]ID, error) {
+	var ids []ID
+
+	dir, err := os.ReadDir(l.dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local store directory: %w", err)
+	}
+
+	for _, binFileEntry := range dir {
+		idString, isBin := strings.CutSuffix(binFileEntry.Name(), ".bin")
+		if !isBin {
+			// Do not include files that don't end in .bin
+			continue
+		}
+
+		var id ID
+		if err := id.Decode(idString); err != nil {
+			// Do not include files that cannot be parsed into a blob ID
+			continue
+		}
+
+		ids = append(ids, ID(id))
+	}
+
+	return ids, nil
+}
+
+// Removes the blob. Errors with ErrBlobNotFound if the blob does not exist.
+func (l *LocalStore) Remove(ctx context.Context, id ID) error {
+	binFileName := id.String() + ".bin"
+	if err := os.Remove(filepath.Join(l.dir, binFileName)); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrBlobNotFound
+		}
+
+		return fmt.Errorf("failed to remove bin file '%s': %w", binFileName, err)
+	}
+
+	return nil
 }

--- a/blob/local_store.go
+++ b/blob/local_store.go
@@ -143,6 +143,11 @@ func (l *LocalStore) List(ctx context.Context) ([]ID, error) {
 	}
 
 	for _, binFileEntry := range dir {
+		if binFileEntry.IsDir() {
+			// Do not include directories
+			continue
+		}
+
 		idString, isBin := strings.CutSuffix(binFileEntry.Name(), ".bin")
 		if !isBin {
 			// Do not include files that don't end in .bin

--- a/integration/singularity/cleanup.go
+++ b/integration/singularity/cleanup.go
@@ -1,0 +1,108 @@
+package singularity
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/motion/blob"
+)
+
+type cleanupSchedulerConfig struct {
+	interval time.Duration
+}
+
+// This is run by the cleanup scheduler to determine whether to clean up a local
+// file.
+type cleanupReadyCallback func(ctx context.Context, blobID blob.ID) (bool, error)
+
+type cleanupScheduler struct {
+	cfg          cleanupSchedulerConfig
+	local        *blob.LocalStore
+	cleanupReady cleanupReadyCallback
+	closing      chan struct{}
+	closed       sync.WaitGroup
+}
+
+func newCleanupScheduler(
+	cfg cleanupSchedulerConfig,
+	local *blob.LocalStore,
+	cleanupReady cleanupReadyCallback,
+) *cleanupScheduler {
+	return &cleanupScheduler{
+		cfg:          cfg,
+		local:        local,
+		cleanupReady: cleanupReady,
+		closing:      make(chan struct{}),
+	}
+}
+
+func (cs *cleanupScheduler) start(ctx context.Context) {
+	cs.closed.Add(1)
+
+	go func() {
+		defer cs.closed.Done()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-cs.closing
+			cancel()
+		}()
+
+		ticker := time.NewTicker(cs.cfg.interval)
+
+		// Run once immediately on startup
+		cs.cleanup(ctx)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cs.cleanup(ctx)
+			}
+		}
+	}()
+}
+
+func (cs *cleanupScheduler) stop(ctx context.Context) {
+	close(cs.closing)
+
+	done := make(chan struct{})
+	go func() {
+		cs.closed.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-done:
+	}
+}
+
+func (cs *cleanupScheduler) cleanup(ctx context.Context) error {
+	ids, err := cs.local.List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list local blob IDs: %w", err)
+	}
+
+	var removals []blob.ID
+	for _, id := range ids {
+		cleanupReady, err := cs.cleanupReady(ctx, id)
+		if err != nil {
+			logger.Warnf("failed to check if blob is ready for cleanup, skipping for this cleanup cycle: %w", err)
+			continue
+		}
+		if cleanupReady {
+			removals = append(removals, id)
+		}
+	}
+
+	for _, blobID := range removals {
+		cs.local.Remove(ctx, blobID)
+	}
+
+	return nil
+}

--- a/integration/singularity/cleanup.go
+++ b/integration/singularity/cleanup.go
@@ -67,7 +67,7 @@ func (cs *cleanupScheduler) start(ctx context.Context) {
 	}()
 }
 
-func (cs *cleanupScheduler) stop(ctx context.Context) {
+func (cs *cleanupScheduler) stop(ctx context.Context) error {
 	close(cs.closing)
 
 	done := make(chan struct{})
@@ -78,7 +78,9 @@ func (cs *cleanupScheduler) stop(ctx context.Context) {
 
 	select {
 	case <-ctx.Done():
+		return ctx.Err()
 	case <-done:
+		return nil
 	}
 }
 

--- a/integration/singularity/cleanup.go
+++ b/integration/singularity/cleanup.go
@@ -51,10 +51,10 @@ func (cs *cleanupScheduler) start(ctx context.Context) {
 		}()
 
 		ticker := time.NewTicker(cs.cfg.interval)
+		defer ticker.Stop()
 
 		// Run once immediately on startup
 		cs.cleanup(ctx)
-		defer ticker.Stop()
 
 		for {
 			select {

--- a/integration/singularity/cleanup_test.go
+++ b/integration/singularity/cleanup_test.go
@@ -1,0 +1,101 @@
+package singularity
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/motion/blob"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupScheduler(t *testing.T) {
+	localDir := filepath.Join(os.TempDir(), "motion-cleanup-test")
+	require.NoError(t, os.MkdirAll(localDir, 0777))
+	local := blob.NewLocalStore(localDir)
+
+	var cleanupNotReadyBlobs []blob.ID
+	var cleanupReadyBlobs []blob.ID
+
+	// Pushes a new blob and optionally add it to the shouldRemove array for the
+	// cleanup test
+	add := func(shouldRemove bool) {
+		data := make([]byte, 16)
+		_, err := rand.Reader.Read(data)
+		require.NoError(t, err)
+
+		desc, err := local.Put(context.Background(), io.NopCloser(bytes.NewReader(data)))
+		require.NoError(t, err)
+
+		if shouldRemove {
+			cleanupReadyBlobs = append(cleanupReadyBlobs, desc.ID)
+		} else {
+			cleanupNotReadyBlobs = append(cleanupNotReadyBlobs, desc.ID)
+		}
+	}
+
+	// Intersperse ready and non-ready blobs
+	for i := 0; i < 100; i++ {
+		add(false)
+		add(true)
+	}
+
+	// Returns true if the value is present in the shouldRemove slice
+	callback := func(ctx context.Context, blobID blob.ID) (bool, error) {
+		for _, other := range cleanupReadyBlobs {
+			if blobID == other {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	cfg := cleanupSchedulerConfig{
+		interval: time.Second,
+	}
+
+	// Before starting the cleanup scheduler, make sure all blobs are present
+	listBefore, err := local.List(context.Background())
+	t.Logf("length before: %v", len(listBefore))
+	require.NoError(t, err)
+	for _, blob := range cleanupNotReadyBlobs {
+		require.Contains(t, listBefore, blob)
+	}
+	for _, blob := range cleanupReadyBlobs {
+		require.Contains(t, listBefore, blob)
+	}
+
+	// Start cleanup scheduler and check that all cleanup ready blobs are
+	// already removed before the first cleanup tick, since there should be one
+	// iteration immediately on startup
+	cleanupScheduler := newCleanupScheduler(cfg, local, callback)
+	cleanupScheduler.start(context.Background())
+
+	time.Sleep(cfg.interval / 2)
+
+	listAfterStart, err := local.List(context.Background())
+	t.Logf("length after start: %v", len(listAfterStart))
+	require.NoError(t, err)
+	for _, blob := range cleanupNotReadyBlobs {
+		require.Contains(t, listAfterStart, blob)
+	}
+	for _, blob := range cleanupReadyBlobs {
+		require.NotContains(t, listAfterStart, blob)
+	}
+
+	// Add the rest of the blobs to cleanup ready, wait for 1 more tick, and
+	// make sure that no more blobs are left
+	cleanupReadyBlobs = append(cleanupReadyBlobs, cleanupNotReadyBlobs...)
+
+	time.Sleep(cfg.interval)
+
+	listAfterTick, err := local.List(context.Background())
+	t.Logf("length after tick: %v", len(listAfterTick))
+	require.NoError(t, err)
+	require.Empty(t, listAfterTick)
+}

--- a/integration/singularity/cleanup_test.go
+++ b/integration/singularity/cleanup_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCleanupScheduler(t *testing.T) {
-	localDir := filepath.Join(os.TempDir(), "motion-cleanup-test")
+	localDir := filepath.Join(t.TempDir(), "motion-cleanup-test")
 	require.NoError(t, os.MkdirAll(localDir, 0777))
 	local := blob.NewLocalStore(localDir)
 

--- a/integration/singularity/id_map.go
+++ b/integration/singularity/id_map.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 
@@ -22,7 +21,7 @@ func newIDMap(dir string) *idMap {
 }
 
 func (im *idMap) path(blobID blob.ID) string {
-	return path.Join(im.dir, blobID.String()+".id")
+	return filepath.Join(im.dir, blobID.String()+".id")
 }
 
 // Inserts a blob ID to Singularity ID mapping.
@@ -53,7 +52,7 @@ func (im *idMap) insert(blobID blob.ID, singularityID int64) error {
 // Maps blob ID to Singularity ID. Returns blob.ErrBlobNotFound if no mapping
 // exists.
 func (im *idMap) get(blobID blob.ID) (int64, error) {
-	fileIDString, err := os.ReadFile(filepath.Join(im.dir, blobID.String()+".id"))
+	fileIDString, err := os.ReadFile(im.path(blobID))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0, blob.ErrBlobNotFound

--- a/integration/singularity/id_map.go
+++ b/integration/singularity/id_map.go
@@ -1,0 +1,85 @@
+package singularity
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+
+	"github.com/filecoin-project/motion/blob"
+)
+
+type idMap struct {
+	dir string
+}
+
+func newIDMap(dir string) *idMap {
+	return &idMap{
+		dir: dir,
+	}
+}
+
+func (im *idMap) path(blobID blob.ID) string {
+	return path.Join(im.dir, blobID.String()+".id")
+}
+
+// Inserts a blob ID to Singularity ID mapping.
+func (im *idMap) insert(blobID blob.ID, singularityID int64) error {
+	idFile, err := os.CreateTemp(im.dir, "motion_local_store_*.id.temp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	defer func() {
+		if err := idFile.Close(); err != nil {
+			logger.Debugw("Failed to close temporary file", "err", err)
+		}
+	}()
+	_, err = idFile.Write([]byte(strconv.FormatUint(uint64(singularityID), 10)))
+	if err != nil {
+		if err := os.Remove(idFile.Name()); err != nil {
+			logger.Debugw("Failed to remove temporary file", "path", idFile.Name(), "err", err)
+		}
+		return fmt.Errorf("failed to write ID file: %w", err)
+	}
+	if err = os.Rename(idFile.Name(), im.path(blobID)); err != nil {
+		return fmt.Errorf("failed to move ID file to store: %w", err)
+	}
+
+	return nil
+}
+
+// Maps blob ID to Singularity ID. Returns blob.ErrBlobNotFound if no mapping
+// exists.
+func (im *idMap) get(blobID blob.ID) (int64, error) {
+	fileIDString, err := os.ReadFile(filepath.Join(im.dir, blobID.String()+".id"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, blob.ErrBlobNotFound
+		}
+
+		return 0, fmt.Errorf("could not read ID file: %w", err)
+	}
+
+	fileID, err := strconv.ParseUint(string(fileIDString), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse Singularity file ID '%s' of ID file for blob '%s': %w", fileIDString, blobID, err)
+	}
+
+	return int64(fileID), nil
+}
+
+// Removes blob ID to Singularity ID mapping. If no ID file existed,
+// blob.ErrBlobNotFound will be returned.
+func (im *idMap) remove(blobID blob.ID) error {
+	if err := os.Remove(im.path(blobID)); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return blob.ErrBlobNotFound
+		}
+
+		return fmt.Errorf("could not read ID file: %w", err)
+	}
+
+	return nil
+}

--- a/integration/singularity/id_map.go
+++ b/integration/singularity/id_map.go
@@ -70,16 +70,17 @@ func (im *idMap) get(blobID blob.ID) (int64, error) {
 	return int64(fileID), nil
 }
 
-// Removes blob ID to Singularity ID mapping. If no ID file existed,
-// blob.ErrBlobNotFound will be returned.
-func (im *idMap) remove(blobID blob.ID) error {
-	if err := os.Remove(im.path(blobID)); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return blob.ErrBlobNotFound
-		}
+// TODO: currently commented to silence unused warning
+// // Removes blob ID to Singularity ID mapping. If no ID file existed,
+// // blob.ErrBlobNotFound will be returned.
+// func (im *idMap) remove(blobID blob.ID) error {
+// 	if err := os.Remove(im.path(blobID)); err != nil {
+// 		if errors.Is(err, os.ErrNotExist) {
+// 			return blob.ErrBlobNotFound
+// 		}
 
-		return fmt.Errorf("could not read ID file: %w", err)
-	}
+// 		return fmt.Errorf("could not read ID file: %w", err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/integration/singularity/store.go
+++ b/integration/singularity/store.go
@@ -421,6 +421,7 @@ func (s *Store) PassGet(w http.ResponseWriter, r *http.Request, id blob.ID) {
 			return
 		}
 
+		logger.Errorw("Could not get singularity file ID", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Wrote a test for the cleanup code while investigating #201. This involved moving cleanup code to its own file. I also used this opportunity to isolate ID mapping code. 

The test is passing from the start, so I'm not sure if it'll fix that issue, but there's a possibility. In any case, it cleans up a bit of mess.

The cleanup scheduler is a new object with the sole purpose of reading through the local bin store and removing files based on the result of a configurable callback, at some interval. A configurable callback allows it to be mocked easily for the test. In `store.go`, the callback is set to the `hasDealForAllProviders()` function. This should be tested next. It'll be a bit more involved since it'll have to be added to the integration test, since singularity has to be running, but I think I know how I'll do it.

A few additional functions have been added to local store: `List()` and `Delete()`. These were previously done inline in `store.go` by manually working with the store directory files, which was kinda hacky. This puts that stuff where it belongs.

About the new ID map object: a separation of concerns refactor. Motion maps blob IDs to Singularity IDs by storing files ending in ".id" in the same directory, named with the stringified motion ID, and containing the Singularity ID in the body.  This processing was all done inline in `store.go` With these changes, this behavior is unmodified, so there should not be any compatibility issues. I originally wrote this because I thought I would be working with IDs in `cleanup.go`, but my final solution did not end up needing it. So in the end it is just a general improvement. It does pave the way for an ID mapping test.

should fix #201, awaiting confirmation by @Angelo-gh3990 